### PR TITLE
Fix for running in subdirectory

### DIFF
--- a/piston-export
+++ b/piston-export
@@ -74,11 +74,12 @@ mkdir($patchDir);
 $hashesToInclude = array_diff($allHashes, $hashesToIgnore);
 $hashesToInclude = array_reverse($hashesToInclude);
 
+$relativePistonDir = trim(`cd $pistonDir && git rev-parse --show-prefix`);
 
 foreach($hashesToInclude as $i => $hash) {
 	$patchFile = str_pad($i, 5, 0, STR_PAD_LEFT) . '.patch';
 	echo "Creating patch for $hash -> $patchDir/$patchFile\n";
-	`git format-patch --relative=$pistonDir --stdout $hash~..$hash > $patchDir/$patchFile`;
+	`git format-patch --relative=$relativePistonDir --stdout $hash~..$hash > $patchDir/$patchFile`;
 }
 
 // Update config without the full destructive powers of Spyc


### PR DESCRIPTION
Module bar pistoned into subdirectory foo. So, in source repository, a/b/.piston.yml. When run as:

cd a
piston-export b destination

Fails (gives a bunch of empty patches), as relative argument to git format-patch is repository relative, not working directory relative
